### PR TITLE
Adjust Event Font Size

### DIFF
--- a/calendar-vue/src/components/calendar/CalendarEvent.vue
+++ b/calendar-vue/src/components/calendar/CalendarEvent.vue
@@ -39,9 +39,14 @@ export default {
   position: absolute;
   height: 5rem;
   background-color: lime;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  cursor: pointer;
 
   p {
     color: black;
+    font-size: 0.75rem;
+    margin: 0;
   }
 }
 </style>

--- a/calendar-vue/src/stores/CalendarStore.ts
+++ b/calendar-vue/src/stores/CalendarStore.ts
@@ -16,6 +16,11 @@ export const useEventStore = defineStore('events', {
                 "fri 2 aug 2024 test",
                 new Date(2024, 7, 2, 12, 0, 0, 0),
                 new Date(2024, 7, 2, 16, 0, 0, 0)
+            ),
+            new CalendarEventModel(
+                "first supervisor meeting",
+                new Date(2024, 9, 4, 15, 0, 0),
+                new Date(2024, 9, 4, 15, 30, 0)
             )
         ] as CalendarEventModel[],
         selectedEvent: null as CalendarEventModel | null


### PR DESCRIPTION
- Reduced default font size of events.
- Set word-break text wrapping on event text.
- Hidden overflow text from event text.
- Added 'first supervisor meeting' as a default event.

(before)
![image](https://github.com/user-attachments/assets/8a508f40-d33c-45a0-a448-109cbaccb4f2)

(after)
![image](https://github.com/user-attachments/assets/f9835751-2e90-4c87-ba2b-1f112a089819)
